### PR TITLE
Potential fix for code scanning alert no. 5: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/build-deploy-prod.yml
+++ b/.github/workflows/build-deploy-prod.yml
@@ -3,6 +3,9 @@
 
 name: build and deploy to prod
 
+permissions:
+  contents: read
+
 on:
   push:
     branches:


### PR DESCRIPTION
Potential fix for [https://github.com/rodekruis/hia-search/security/code-scanning/5](https://github.com/rodekruis/hia-search/security/code-scanning/5)

In general, the fix is to add an explicit `permissions` block that grants only the minimal required scopes for `GITHUB_TOKEN`. For a typical build-and-deploy workflow that only needs to read the repository contents and does not push back to GitHub, `contents: read` is sufficient. This both documents intended privileges and prevents accidental elevation if defaults change.

The best fix here without changing existing functionality is to add a top-level `permissions` block (applies to all jobs) right after the `name:` or `on:` section, setting `contents: read`. None of the steps shown require write access via `GITHUB_TOKEN`; Docker login/push and Azure deploy use secrets. Therefore, limiting `contents` to `read` will not break the workflow. We do not need job-specific overrides unless a future job requires additional scopes.

Concretely, in `.github/workflows/build-deploy-prod.yml`, insert:

```yaml
permissions:
  contents: read
```

near the top of the file (e.g., after `name: build and deploy to prod`). No imports or additional code are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
